### PR TITLE
Add aggressive eviction when tier exceeds max_usage_percent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ claude.md
 # Config files with secrets
 config.yaml
 *.key
+leo@*


### PR DESCRIPTION
When cache tier exceeds max_usage_percent but has no blocked placements with higher priority, files now get evicted automatically in Pass 3b.

Eviction policy: priority (low first) -> age (old first) -> size (large first)

This ensures older low-priority files are evicted first, keeping the cache under the configured limit even when there are no incoming high-priority files.