### PR TITLE
Fix memory leak: use status() instead of output() for rsync

### DIFF
--- a/src/balancer/state.rs
+++ b/src/balancer/state.rs
@@ -52,14 +52,12 @@ impl PlanningState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    fn create_test_tier(name: &str, _size: u64) -> Tier {
-        let temp_dir = std::env::temp_dir().join(format!("tier_state_test_{name}"));
-        fs::create_dir_all(&temp_dir).unwrap();
-        Tier::new(name.to_string(), temp_dir, 1, None, None).unwrap()
+    fn create_test_tier(name: &str, total_size: u64) -> Tier {
+        // Use mock disk with specified total size at 0% usage
+        Tier::new_mock_with_usage(name, 1, None, total_size, 0)
     }
 
     #[test]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -197,6 +197,7 @@ mod tests {
     use std::time::SystemTime;
 
     fn create_test_tier(name: &str) -> Tier {
+        // Executor tests need real filesystem for actual file operations
         let temp_dir = std::env::temp_dir().join(format!("executor_test_{name}"));
         std::fs::create_dir_all(&temp_dir).unwrap();
         Tier::new(name.to_string(), temp_dir, 1, None, None).unwrap()

--- a/src/mover/mod.rs
+++ b/src/mover/mod.rs
@@ -160,25 +160,20 @@ impl Mover for RsyncMover {
             destination.display()
         );
 
-        // Execute rsync
-        let output = cmd.output()?;
+        // Execute rsync - use status() instead of output() to avoid buffering
+        // large amounts of stdout/stderr in memory for big files
+        let status = cmd.status()?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-
+        if !status.success() {
             tracing::error!(
-                "Rsync failed for {} -> {}\nstdout: {}\nstderr: {}",
+                "Rsync failed for {} -> {}",
                 source.display(),
-                destination.display(),
-                stdout,
-                stderr
+                destination.display()
             );
 
             return Err(io::Error::other(format!(
-                "rsync failed with exit code {:?}: {}",
-                output.status.code(),
-                stderr
+                "rsync failed with exit code {:?}",
+                status.code()
             )));
         }
 

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -61,7 +61,6 @@ impl PlacementStrategy {
 mod tests {
     use super::*;
     use crate::conditions::{AgeCondition, AlwaysTrueCondition};
-    use std::fs;
     use std::path::PathBuf;
     use std::time::{Duration, SystemTime};
 
@@ -75,10 +74,12 @@ mod tests {
         }
     }
 
+    // Test constants
+    const TB: u64 = 1024 * 1024 * 1024 * 1024;
+
     fn create_test_tier(name: &str) -> Tier {
-        let temp_dir = std::env::temp_dir().join(format!("tier_test_{name}"));
-        fs::create_dir_all(&temp_dir).unwrap();
-        Tier::new(name.to_string(), temp_dir, 1, None, None).unwrap()
+        // Use fixed 1TB disk at 0% usage for predictable tests
+        Tier::new_mock_with_usage(name, 1, None, TB, 0)
     }
 
     #[test]


### PR DESCRIPTION
When moving large files (40GB+), cmd.output() was buffering all stdout/stderr in memory, potentially consuming gigabytes of RAM.

Changed to cmd.status() which doesn't buffer output, only returns exit code. This reduces memory usage during file operations.