### PR TITLE
Discard rsync stdout/stderr to prevent memory buildup

### DIFF
--- a/src/mover/mod.rs
+++ b/src/mover/mod.rs
@@ -160,8 +160,11 @@ impl Mover for RsyncMover {
             destination.display()
         );
 
-        // Execute rsync - use status() instead of output() to avoid buffering
-        // large amounts of stdout/stderr in memory for big files
+        // Execute rsync with stdout/stderr discarded to prevent memory buildup
+        // from --progress output (especially important for large files)
+        use std::process::Stdio;
+        cmd.stdout(Stdio::null()).stderr(Stdio::null());
+
         let status = cmd.status()?;
 
         if !status.success() {


### PR DESCRIPTION
Use Stdio::null() to discard rsync output instead of letting it flow to terminal/systemd. This prevents memory accumulation when using --progress flag with large files (40GB+).

Without this, rsync --progress output was being buffered somewhere in the system, causing 15GB+ memory usage during file copies.