### PR TITLE
Add libc as explicit dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "fs2",
  "hostname",
  "lazy-regex",
+ "libc",
  "nix 0.29.0",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json", "fmt"] }
 
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
+libc = "0.2.177"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["signal", "process"] }

--- a/src/mover/native.rs
+++ b/src/mover/native.rs
@@ -19,7 +19,6 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
     // Tell kernel to drop cached pages after reading (prevents huge page cache buildup)
     #[cfg(target_os = "linux")]
     {
-        use nix::libc;
         use std::os::unix::io::AsRawFd;
         let fd = file.as_raw_fd();
         unsafe {

--- a/src/mover/native.rs
+++ b/src/mover/native.rs
@@ -16,20 +16,17 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
     let file_size = metadata.len();
     let size_gb = file_size as f64 / (1024.0 * 1024.0 * 1024.0);
 
-    // Tell kernel to drop cached pages after reading (prevents huge page cache buildup)
     #[cfg(target_os = "linux")]
-    {
-        use std::os::unix::io::AsRawFd;
-        let fd = file.as_raw_fd();
-        unsafe {
-            libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_SEQUENTIAL);
-            libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED);
-        }
-        tracing::debug!(
-            "Applied POSIX_FADV_DONTNEED to {} ({:.2} GB) to prevent page cache buildup",
-            path.display(),
-            size_gb
-        );
+    use std::os::unix::io::AsRawFd;
+
+    // Get file descriptor for Linux optimizations
+    #[cfg(target_os = "linux")]
+    let fd = file.as_raw_fd();
+
+    // Tell kernel we'll read sequentially (optimization hint)
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_SEQUENTIAL);
     }
 
     tracing::info!("Hashing file: {} ({:.2} GB)", path.display(), size_gb);
@@ -41,6 +38,13 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
         let mut reader = BufReader::new(file);
         reader.read_to_end(&mut buffer)?;
         let hash = xxh3_128(&buffer);
+
+        // Drop cached pages for small files too
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::posix_fadvise(fd, 0, file_size as i64, libc::POSIX_FADV_DONTNEED);
+        }
+
         tracing::info!(
             "Hash complete: {} ({:.3} MB) = {:032x}",
             path.display(),
@@ -50,12 +54,15 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
         return Ok(format!("{:032x}", hash));
     }
 
-    // For large files, use streaming
+    // For large files, use streaming and drop pages progressively
     let mut reader = BufReader::with_capacity(BUFFER_SIZE, file);
     let mut hasher = xxhash_rust::xxh3::Xxh3Builder::new().build();
     let mut buffer = vec![0u8; BUFFER_SIZE];
     let mut total_read = 0u64;
     let mut last_log_gb = 0;
+
+    #[cfg(target_os = "linux")]
+    let mut last_fadvise_offset = 0i64;
 
     loop {
         let bytes_read = reader.read(&mut buffer)?;
@@ -65,6 +72,31 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
 
         hasher.update(&buffer[..bytes_read]);
         total_read += bytes_read as u64;
+
+        // Drop cached pages every 100MB to prevent page cache buildup
+        #[cfg(target_os = "linux")]
+        {
+            const DROP_INTERVAL: i64 = 100 * 1024 * 1024; // 100MB
+            let current_offset = total_read as i64;
+            if current_offset - last_fadvise_offset >= DROP_INTERVAL {
+                let drop_len = current_offset - last_fadvise_offset;
+                unsafe {
+                    libc::posix_fadvise(
+                        fd,
+                        last_fadvise_offset,
+                        drop_len,
+                        libc::POSIX_FADV_DONTNEED,
+                    );
+                }
+                tracing::debug!(
+                    "Dropped {}MB of page cache for {} (offset: {:.2}GB)",
+                    drop_len / (1024 * 1024),
+                    path.display(),
+                    last_fadvise_offset as f64 / (1024.0 * 1024.0 * 1024.0)
+                );
+                last_fadvise_offset = current_offset;
+            }
+        }
 
         // Log progress for very large files
         let current_gb = total_read / (1024 * 1024 * 1024);
@@ -77,6 +109,25 @@ pub fn calculate_checksum_native(path: &Path) -> io::Result<String> {
             );
             last_log_gb = current_gb;
         }
+    }
+
+    // Drop any remaining cached pages
+    #[cfg(target_os = "linux")]
+    if last_fadvise_offset < total_read as i64 {
+        let remaining = total_read as i64 - last_fadvise_offset;
+        unsafe {
+            libc::posix_fadvise(
+                fd,
+                last_fadvise_offset,
+                remaining,
+                libc::POSIX_FADV_DONTNEED,
+            );
+        }
+        tracing::debug!(
+            "Dropped final {}MB of page cache for {}",
+            remaining / (1024 * 1024),
+            path.display()
+        );
     }
 
     let hash = hasher.digest128();


### PR DESCRIPTION
Better to have libc as a direct dependency rather than relying on nix re-exporting it. This makes the dependency explicit and avoids potential issues if nix changes its exports in the future.